### PR TITLE
update apt version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12
 
 platforms:
   - name: ubuntu-12.04
@@ -16,7 +17,7 @@ platforms:
       apt:
         compiletime: true
 
-  - name: centos-6.4
+  - name: centos-6.9
     driver_config:
       network:
       - ["private_network", {ip: "33.33.33.11"}]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email 'robertomoutinho@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.1006'
+version          '0.3.2001'
 
 depends 'ark', '~> 0.9.0'
 depends 'java', '~> 1.39.0'
-depends 'apt', '~> 5.0.1'
+depends 'apt', '~> 6.1.2'
 
 supports 'ubuntu', '= 12.04'
 supports 'centos', '>= 6.4'


### PR DESCRIPTION
also:

Made kitchen working with the current version of Java cookbook. (Chef 12)
Updated the Centos box since 6.4 is no longer found.